### PR TITLE
Fixed support for large IPL encryption

### DIFF
--- a/ipl.h
+++ b/ipl.h
@@ -5,7 +5,7 @@
 
 //0xF60
 #define MAX_IPLBLK_DATA_SIZE (0xF60)
-#define MAX_IPL_SIZE         (0x80000)
+#define MAX_IPL_SIZE         (0xFFFFFF)
 #define MAX_NUM_IPLBLKS    (MAX_IPL_SIZE / sizeof(iplEncBlk))
 
 typedef struct


### PR DESCRIPTION
IPL encryption was limited to a size of 0x8000.